### PR TITLE
Improved loading of minified url, popup can now have styling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,5 +10,5 @@
    "manifest_version": 2,
    "name": "TinyURL Maker",
    "permissions": [ "tabs", "<all_urls>" ],
-   "version": "1.0"
+   "version": "1.1"
 }

--- a/popup.html
+++ b/popup.html
@@ -2,10 +2,11 @@
 <html>
   <head>
     <title>Get TinyURL popup</title>
+    <script src=popup.js></script>
   </head>
-   <script src=popup.js>
- </script>
   <body>
+    <b>TinyURL:</b>
+    <p id="URLHere">Loading...</p>
   </body>
  
  </html>

--- a/popup.js
+++ b/popup.js
@@ -4,5 +4,17 @@ chrome.tabs.query({
 }, function(tabs) {
     var tab = tabs[0];
     var url = tab.url;
-	document.write ('<iframe id="url" frameBorder="2" scrolling="yes" height=40 width=250 src="http://tinyurl.com/api-create.php?url=' + url + '"/>');
+    GetTinyURL(url, (correctURL)=>{
+        document.getElementById("URLHere").innerHTML = correctURL;
+    });
 });
+
+function GetTinyURL(url, callback){
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET','http://tinyurl.com/api-create.php?url=' + url);
+    xhr.onreadystatechange = function(){
+        if(this.readyState===4)
+            callback(this.responseText);
+    }
+    xhr.send();
+}


### PR DESCRIPTION
I've removed the dependency on the iframe and instead inserted the minified url directly into html of the popup, this will allow the popup to have a style and will also display loading... when the url is being fetched.

I've also bumped up the version number.